### PR TITLE
Capture "Other" Web Vitals

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -46,6 +46,14 @@ ___TEMPLATE_PARAMETERS___
         "simpleValueType": true,
         "defaultValue": false,
         "help": "If you check this option, then each measurement will be nested under its own property in the webVitalsMeasurement dataLayer object. If you leave this option unchecked, then each measurement will use a shared set of object properties (and thus overwrite previous values)."
+      },
+      {
+        "type": "CHECKBOX",
+        "name": "captureOtherWebVitals",
+        "checkboxText": "Capture Other Web Vitals",
+        "simpleValueType": true,
+        "defaultValue": false,
+        "help": "If you check this option, then Other Web Vitals (https://web.dev/vitals/#other-web-vitals), TTFB and FCP, will also be captured."
       }
     ]
   },
@@ -110,6 +118,10 @@ const setMilestones = () => {
   wv.getFID(process);
   wv.getCLS(process);
   wv.getLCP(process);
+  if (data.captureOtherWebVitals) {
+    wv.getTTFB(process);
+    wv.getFID(process);
+  }
   data.gtmOnSuccess();
 };
 

--- a/template.tpl
+++ b/template.tpl
@@ -120,7 +120,7 @@ const setMilestones = () => {
   wv.getLCP(process);
   if (data.captureOtherWebVitals) {
     wv.getTTFB(process);
-    wv.getFID(process);
+    wv.getFCP(process);
   }
   data.gtmOnSuccess();
 };


### PR DESCRIPTION
This is a work in progress of https://github.com/gtm-templates-simo-ahava/core-web-vitals/issues/2.

Although it's untested, I don't see how I configure it from Tag Manager. So it is really a work in progress 😺 

I also thought about allowing the user to select which events they want to capture, so one could check "TTFB", "FID", and even "CLS", "FCP" etc. although I was not completely sold on this approach.